### PR TITLE
fix: resolve path error by correcting 'KR_' prefix handling

### DIFF
--- a/src/ptsd/processor.py
+++ b/src/ptsd/processor.py
@@ -146,7 +146,8 @@ class TranslationMerger:
         self,
         file: ProjectFile,
     ) -> None:
-        raw_path = self.root_dir / "kr" / f"KR_{file.name}"
+        fake_path = AnyioPath(self.root_dir / "kr" / file.name)
+        raw_path = fake_path.parent / f"KR_{fake_path.name}"
         output_path = self.target_dir / file.name
 
         if not (translations := await self.client.request("GET", f"/files/{file.id}/translation")):


### PR DESCRIPTION
Previously, the raw_path calculation missed the 'KR_' prefix in file paths. Updated the logic to include a wrong_path variable for handling paths correctly, ensuring the 'KR_' prefix is added before generating raw_path.