### PR TITLE
fix: correct use of secrets in GitHub Actions

### DIFF
--- a/.github/workflows/update-kor.yml
+++ b/.github/workflows/update-kor.yml
@@ -117,4 +117,4 @@ jobs:
         working-directory: main-repo
         run: uv run ptsd upload --storyline-folder ../storyline
         env:
-          PARATRANZ_TOKENS: ${{ env.PARATRANZ_TOKENS }}
+          PARATRANZ_TOKENS: ${{ secrets.PARATRANZ_TOKENS }}


### PR DESCRIPTION
Previously, secrets were mistakenly referenced as environment variables (env). This fix ensures secrets are properly accessed using GitHub's `secrets` context, improving security and preventing potential misconfigurations.